### PR TITLE
Expose module Data.Text.Format.Types.Internal.

### DIFF
--- a/text-format.cabal
+++ b/text-format.cabal
@@ -1,5 +1,5 @@
 name:           text-format
-version:        0.3.0.8
+version:        0.3.0.9
 license:        BSD3
 license-file:   LICENSE
 homepage:       https://github.com/bos/text-format
@@ -32,11 +32,11 @@ library
     Data.Text.Buildable
     Data.Text.Format.Params
     Data.Text.Format.Types
+    Data.Text.Format.Types.Internal
 
   other-modules:
     Data.Text.Format.Functions
     Data.Text.Format.Int
-    Data.Text.Format.Types.Internal
 
   build-depends:
     array,


### PR DESCRIPTION
Hi.
In some cases, there is need to construct Format in some way. In my case, it's localization: text format strings for messages in various languages are loaded from file. Data.Text.Format.Types.Internal module is not imported by default when someone imports simply Data.Text.Format, so, I think, there is really no danger that someone will use this module unintentionally.